### PR TITLE
ListページのLPコンテキストメニューを改良

### DIFF
--- a/css/list_style.css
+++ b/css/list_style.css
@@ -81,9 +81,10 @@ table {
 }
 
 .modify_menu {
-    position: relative;
+    position: absolute;
     z-index: 3;
-    width: 100%;
+    width: auto;
+    right: 0;
 }
 
 .modify_menu > div {
@@ -113,6 +114,10 @@ hr {
     margin: 0px;
 }
 
+details {
+    position: relative;
+}
+
 details > summary {
     list-style: none;
 }
@@ -121,7 +126,7 @@ details > summary::-webkit-details-marker {
     display: none;
 }
 
-details[open]>summary::before {
+details[open] > summary::before {
     position: fixed;
     top: 0;
     right: 0;

--- a/css/list_style.css
+++ b/css/list_style.css
@@ -81,9 +81,8 @@ table {
 }
 
 .modify_menu {
-    display: none;
     position: relative;
-    z-index: 2;
+    z-index: 3;
     width: 100%;
 }
 
@@ -112,4 +111,25 @@ table {
 
 hr {
     margin: 0px;
+}
+
+details > summary {
+    list-style: none;
+}
+
+details > summary::-webkit-details-marker {
+    display: none;
+}
+
+details[open]>summary::before {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 2;
+    display: block;
+    cursor: default;
+    content: " ";
+    background: transparent;
 }

--- a/css/list_style.css
+++ b/css/list_style.css
@@ -110,8 +110,11 @@ table {
     border-radius: 8px;
 }
 
-hr {
+.hr {
+    display: block;
+    height: 0;
     margin: 0px;
+    border-top: solid 1px gray;
 }
 
 details {

--- a/templates/list.html
+++ b/templates/list.html
@@ -7,16 +7,6 @@
     <link rel="stylesheet" href="static/css/common_style.css">
     <link rel="stylesheet" href="static/css/list_style.css">
 </head>
-<script>
-    function click_menu_button(obj) {
-        let modify_menu = obj.nextElementSibling;
-        if (modify_menu.style.display == "block") {
-            modify_menu.style.display = "none";
-        } else {
-            modify_menu.style.display = "block";
-        }
-    }
-</script>
 <body>
     <header>
         <a href="/"><img id="title_img" src="static/resources/title.png"></a>
@@ -55,24 +45,28 @@
         <div class="flex_box">
             {% for pair in list %}
                 <div class="flex_item">
-                    <div class="modify_button" onclick="click_menu_button(this)">
-                        <div></div>
-                        <div></div>
-                        <div></div>
-                    </div>
-                    <div class="modify_menu">
-                        <div>
-                            <form method="POST">
-                                <input type="hidden" name="name" value="{{ pair.name }}">
-                                <input class="modify_menu_button" type="submit" name="submit" value="Modify">
-                            </form>
-                            <hr>
-                            <form method="POST" onsubmit="return confirm('Delete {{ pair.name }}?');">
-                                <input type="hidden" name="name" value="{{ pair.name }}">
-                                <input class="modify_menu_button" type="submit" name="submit" value="Delete">
-                            </form>
+                    <details>
+                        <summary>
+                            <div class="modify_button">
+                                <div></div>
+                                <div></div>
+                                <div></div>
+                            </div>
+                        </summary>
+                        <div class="modify_menu">
+                            <div>
+                                <form method="POST">
+                                    <input type="hidden" name="name" value="{{ pair.name }}">
+                                    <input class="modify_menu_button" type="submit" name="submit" value="Modify">
+                                </form>
+                                <hr>
+                                <form method="POST" onsubmit="return confirm('Delete {{ pair.name }}?');">
+                                    <input type="hidden" name="name" value="{{ pair.name }}">
+                                    <input class="modify_menu_button" type="submit" name="submit" value="Delete" style="color:RED;">
+                                </form>
+                            </div>
                         </div>
-                    </div>
+                    </details>
 
                     <h3 class="underline">{{pair.name}}</h3>
                     <ul>

--- a/templates/list.html
+++ b/templates/list.html
@@ -35,7 +35,7 @@
                     </td>
                 </tr>
             </table>
-            <hr />
+            <span class="hr">
         </nav>
     </div>
 
@@ -59,7 +59,7 @@
                                     <input type="hidden" name="name" value="{{ pair.name }}">
                                     <input class="modify_menu_button" type="submit" name="submit" value="Modify">
                                 </form>
-                                <hr>
+                                <span class="hr">
                                 <form method="POST" onsubmit="return confirm('Delete {{ pair.name }}?');">
                                     <input type="hidden" name="name" value="{{ pair.name }}">
                                     <input class="modify_menu_button" type="submit" name="submit" value="Delete" style="color:RED;">


### PR DESCRIPTION
## メインの修正
- 今までJSを使用して開閉処理をしていたのを`<details>`と`<summary>`を使用するようにした
- メニューは一つのみ開けるようにした
- 開いたメニューはそれ以外の任意の場所をクリックで閉じるようにした

## 細かな修正
- 「Delete」を赤文字にした
- 「Modify」と「Delete」の境界線（`hr`)を`span`及びCSSで指定することで`hr`タグ特有の影を無くした